### PR TITLE
Support parenthesis

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -30,6 +30,10 @@ Support for parenthesis.
 
 e.g. `2d8`
 
+### Restrict die ranges.
+
+This would be the common ranges, including 100. Hence: 4, 6, 8, 10, 12, 20, 100.
+
 ## Testing
 
 Fuzzing against the grammar would be good.

--- a/knifey-core/src/data.rs
+++ b/knifey-core/src/data.rs
@@ -45,20 +45,20 @@ impl Term {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expr {
-    Add { lhs: Box<Term>, rhs: Box<Term> },
-    Sub { lhs: Box<Term>, rhs: Box<Term> },
+    Add { lhs: Box<Term>, rhs: Box<Expr> },
+    Sub { lhs: Box<Term>, rhs: Box<Expr> },
     Term(Box<Term>),
 }
 
 impl Expr {
-    pub fn add(lhs: Term, rhs: Term) -> Expr {
+    pub fn add(lhs: Term, rhs: Expr) -> Expr {
         Expr::Add {
             lhs: Box::new(lhs),
             rhs: Box::new(rhs),
         }
     }
 
-    pub fn sub(lhs: Term, rhs: Term) -> Expr {
+    pub fn sub(lhs: Term, rhs: Expr) -> Expr {
         Expr::Sub {
             lhs: Box::new(lhs),
             rhs: Box::new(rhs),

--- a/knifey-core/src/eval.rs
+++ b/knifey-core/src/eval.rs
@@ -3,8 +3,8 @@ use crate::data::*;
 /// A simple tree walk interpreter.
 pub fn eval(expr: Expr) -> Value {
     match expr {
-        Expr::Add { lhs, rhs } => eval_term(*lhs).add(eval_term(*rhs)),
-        Expr::Sub { lhs, rhs } => eval_term(*lhs).sub(eval_term(*rhs)),
+        Expr::Add { lhs, rhs } => eval_term(*lhs).add(eval(*rhs)),
+        Expr::Sub { lhs, rhs } => eval_term(*lhs).sub(eval(*rhs)),
         Expr::Term(term) => eval_term(*term),
     }
 }
@@ -12,7 +12,7 @@ pub fn eval(expr: Expr) -> Value {
 pub fn eval_term(term: Term) -> Value {
     match term {
         Term::Constant(Constant { value }) => Value::Int64(value),
-        Term::Dice(Dice { value }) => Value::Int64(fastrand::i64(1..value)),
+        Term::Dice(Dice { value }) => Value::Int64(fastrand::i64(1..=value)),
         Term::Paren(expr) => eval(expr),
     }
 }
@@ -21,6 +21,10 @@ pub fn eval_term(term: Term) -> Value {
 mod test {
     use super::*;
     use crate::parse;
+
+    pub fn parse_eval(input: &str) -> Value {
+        eval(parse::parse_expr(input).expect("parse"))
+    }
 
     #[test]
     fn eval_dice_works() {
@@ -42,7 +46,7 @@ mod test {
     fn eval_add_works() {
         let value = 2;
         let constant = Term::constant(value);
-        let addition = Expr::add(constant.clone(), constant.clone());
+        let addition = Expr::add(constant.clone(), Expr::term(constant.clone()));
         let result = eval(addition).as_i64().expect("cast");
         assert_eq!(result, value + value);
     }
@@ -51,7 +55,7 @@ mod test {
     fn eval_sub_works() {
         let value = 2;
         let constant = Term::constant(value);
-        let subtraction = Expr::sub(constant.clone(), constant.clone());
+        let subtraction = Expr::sub(constant.clone(), Expr::term(constant.clone()));
         let result = eval(subtraction).as_i64().expect("cast");
         assert_eq!(result, value - value);
     }
@@ -60,8 +64,8 @@ mod test {
     fn eval_nested_works_01() {
         let value = 2;
         let constant = Term::constant(value);
-        let addition = Expr::add(constant.clone(), constant.clone());
-        let nested = Expr::sub(constant.clone(), Term::paren(addition));
+        let addition = Expr::add(constant.clone(), Expr::term(constant.clone()));
+        let nested = Expr::sub(constant.clone(), addition);
         let result = eval(nested).as_i64().expect("cast");
         assert_eq!(result, value - (value + value));
     }
@@ -70,8 +74,8 @@ mod test {
     fn eval_nested_works_02() {
         let value = 2;
         let constant = Term::constant(value);
-        let addition = Expr::add(constant.clone(), constant.clone());
-        let nested = Expr::sub(Term::paren(addition), constant.clone());
+        let addition = Expr::add(constant.clone(), Expr::term(constant.clone()));
+        let nested = Expr::sub(Term::paren(addition), Expr::term(constant.clone()));
         let result = eval(nested).as_i64().expect("cast");
         assert_eq!(result, (value + value) - value);
     }
@@ -80,22 +84,119 @@ mod test {
     fn eval_dice_in_bounds() {
         let value = 20;
         let dice = Term::dice(value);
-        let addition = Expr::add(dice.clone(), dice.clone());
+        let addition = Expr::add(dice.clone(), Expr::term(dice.clone()));
         let result = eval(addition).as_i64().expect("cast");
         assert!(result >= 1 && result <= (value * 2));
     }
 
     #[test]
     fn eval_expr_source_01() {
-        let expr = parse::parse_expr("d20 + 5").expect("parse");
-        let result = eval(expr).as_i64().expect("cast");
+        let result = parse_eval("d20 + 5").as_i64().expect("cast");
         assert!(result >= 5 && result <= (5 + 20));
     }
 
     #[test]
     fn eval_expr_source_02() {
-        let expr = parse::parse_expr("100 - 20").expect("parse");
+        assert_eq!(parse_eval("100 - 20").as_i64().expect("cast"), 80);
+    }
+
+    #[test]
+    fn eval_parenthesis_01() {
+        // (100 - 20) + 1 => 81
+        let expr = Expr::add(
+            Term::paren(Expr::sub(
+                Term::constant(100),
+                Expr::term(Term::constant(20)),
+            )),
+            Expr::term(Term::constant(1)),
+        );
         let result = eval(expr).as_i64().expect("cast");
-        assert_eq!(result, 80);
+        assert_eq!(result, 81);
+    }
+
+    #[test]
+    fn eval_parenthesis_02() {
+        // 100 - (20 + 1) => 79
+        let expr = Expr::sub(
+            Term::constant(100),
+            Expr::term(Term::paren(Expr::add(
+                Term::constant(20),
+                Expr::term(Term::constant(1)),
+            ))),
+        );
+        let result = eval(expr).as_i64().expect("cast");
+        assert_eq!(result, 79);
+    }
+
+    #[test]
+    fn eval_parenthesis_03() {
+        // ((100 + 10) - 20) + 1 => 91
+        let expr = Expr::add(
+            Term::paren(Expr::sub(
+                Term::paren(Expr::add(
+                    Term::constant(100),
+                    Expr::term(Term::constant(10)),
+                )),
+                Expr::term(Term::constant(20)),
+            )),
+            Expr::term(Term::constant(1)),
+        );
+        let result = eval(expr).as_i64().expect("cast");
+        assert_eq!(result, 91);
+    }
+
+    #[test]
+    fn eval_parenthesis_04() {
+        // (100 - (10 - 100)) + 1 => 191
+        let expr = Expr::add(
+            Term::paren(Expr::sub(
+                Term::constant(100),
+                Expr::term(Term::paren(Expr::sub(
+                    Term::constant(10),
+                    Expr::term(Term::constant(100)),
+                ))),
+            )),
+            Expr::term(Term::constant(1)),
+        );
+        let result = eval(expr).as_i64().expect("cast");
+        assert_eq!(result, 191);
+    }
+
+    #[test]
+    fn eval_parenthesis_05() {
+        // ((100 - 10) - 100) + 1 => -9
+        let expr = Expr::add(
+            Term::paren(Expr::sub(
+                Term::paren(Expr::sub(
+                    Term::constant(100),
+                    Expr::term(Term::constant(10)),
+                )),
+                Expr::term(Term::constant(100)),
+            )),
+            Expr::term(Term::constant(1)),
+        );
+        let result = eval(expr).as_i64().expect("cast");
+        assert_eq!(result, -9);
+    }
+
+    #[test]
+    fn eval_parenthesis_06() {
+        // (1)
+        let expr = Expr::term(Term::paren(Expr::term(Term::constant(1))));
+        let result = eval(expr).as_i64().expect("cast");
+        assert_eq!(result, 1);
+    }
+
+    #[test]
+    fn eval_parenthesis_deeply_nested() {
+        assert_eq!(parse_eval("(((1)))").as_i64().expect("cast"), 1);
+    }
+
+    #[test]
+    fn eval_idempotent() {
+        let expr = Expr::term(Term::constant(100));
+        let result1 = eval(expr.clone()).as_i64().expect("cast");
+        let result2 = eval(expr.clone()).as_i64().expect("cast");
+        assert_eq!(result1, result2);
     }
 }


### PR DESCRIPTION
This supports parenthesis but for now doesn't mean much as addition and
subtraction have equal precedence. If we add factors such as
multiplication and division then we can better utilise this
functionality. In that case, the evaluator must change and always
evaluate the term of precedence first if it differs from the default
(left) factor.

This is a bit neater in general than what was there before, which was to
add an implicit paren term on the right hand side to make things work.
It changes the AST to express binops as Term `op` Expr pairs which more
closely matches the grammar written in documentation.