### PR TITLE
Add roundtrip law test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,8 @@ dependencies = [
  "blake3",
  "fastrand",
  "nom",
+ "quickcheck",
+ "rand",
 ]
 
 [[package]]
@@ -712,6 +714,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/knifey-core/Cargo.toml
+++ b/knifey-core/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 nom = "7.1.1"
 fastrand = "1.7.0"
 blake3 = "1.3.1"
+quickcheck = { version = "1.0.3", default-features = false, features = [] }
+rand = { version = "0.8.5", features = ["small_rng", "alloc"] }

--- a/knifey-core/src/data.rs
+++ b/knifey-core/src/data.rs
@@ -1,3 +1,5 @@
+use quickcheck::{Arbitrary, Gen};
+
 /// A dice roll between one and `value` inclusive.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Dice {
@@ -8,6 +10,15 @@ pub struct Dice {
 impl Dice {
     pub fn new(value: i64) -> Dice {
         Dice { value }
+    }
+}
+
+impl Arbitrary for Dice {
+    fn arbitrary(g: &mut Gen) -> Dice {
+        let bound = (u64::arbitrary(g) % (i64::MAX as u64)) + 2;
+        Dice {
+            value: bound as i64,
+        }
     }
 }
 
@@ -22,11 +33,32 @@ impl Constant {
     }
 }
 
+impl Arbitrary for Constant {
+    fn arbitrary(g: &mut Gen) -> Constant {
+        Constant {
+            value: i64::arbitrary(g),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum Term {
     Dice(Dice),
     Constant(Constant),
     Paren(Expr),
+}
+
+impl Arbitrary for Term {
+    fn arbitrary(g: &mut Gen) -> Term {
+        frequency(
+            &[
+                (3, |g| Term::Constant(*Box::arbitrary(g))),
+                (3, |g| Term::Dice(*Box::arbitrary(g))),
+                (1, |g| Term::Paren(Expr::arbitrary(g))),
+            ],
+            g,
+        )
+    }
 }
 
 impl Term {
@@ -51,6 +83,21 @@ pub enum Factor {
     // Div { lhs: Box<Term>, rhs: Box<Expr> },
 }
 
+impl Arbitrary for Factor {
+    fn arbitrary(g: &mut Gen) -> Factor {
+        frequency(
+            &[
+                (1, |g| Factor::Mul {
+                    lhs: Box::arbitrary(g),
+                    rhs: Box::arbitrary(g),
+                }),
+                (2, |g| Factor::Term(Box::arbitrary(g))),
+            ],
+            g,
+        )
+    }
+}
+
 impl Factor {
     pub fn mul(lhs: Term, rhs: Factor) -> Factor {
         Factor::Mul {
@@ -69,6 +116,45 @@ pub enum Expr {
     Add { lhs: Box<Factor>, rhs: Box<Expr> },
     Sub { lhs: Box<Factor>, rhs: Box<Expr> },
     Factor(Box<Factor>),
+}
+
+pub fn frequency<A: Clone>(weighted_options: &[(usize, fn(&mut Gen) -> A)], g: &mut Gen) -> A {
+    assert!(!weighted_options.is_empty());
+    assert!(!weighted_options.iter().all(|(w, _)| w == &0));
+    assert!(!weighted_options.iter().any(|(w, _)| w < &0));
+    let total: usize = weighted_options.iter().map(|(w, _)| w).sum();
+    let mut choice = rand::random::<usize>() % total + 1;
+    for (weight, option) in weighted_options {
+        if choice <= *weight {
+            return option(g);
+        }
+        choice -= weight;
+    }
+    std::unreachable!()
+}
+
+pub fn oneof<A: Clone>(options: &[fn(&mut Gen) -> A], g: &mut Gen) -> A {
+    let weighted_options: Vec<_> = options.iter().map(|f| (1 as usize, *f)).collect();
+    frequency(weighted_options.as_slice(), g)
+}
+
+impl Arbitrary for Expr {
+    fn arbitrary(g: &mut Gen) -> Expr {
+        frequency(
+            &[
+                (1, |g| Expr::Add {
+                    lhs: Box::arbitrary(g),
+                    rhs: Box::arbitrary(g),
+                }),
+                (1, |g| Expr::Sub {
+                    lhs: Box::arbitrary(g),
+                    rhs: Box::arbitrary(g),
+                }),
+                (3, |g| Expr::Factor(*Box::arbitrary(g))),
+            ],
+            g,
+        )
+    }
 }
 
 impl Expr {

--- a/knifey-core/src/parse.rs
+++ b/knifey-core/src/parse.rs
@@ -74,7 +74,10 @@ pub fn parse_expr(input: &str) -> Result<Expr, nom::Err<nom::error::Error<&str>>
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::data;
+    use crate::pretty;
     use crate::test::golden::check_golden_expr;
+    use quickcheck::quickcheck;
 
     #[test]
     fn parse_expr_works() {
@@ -119,11 +122,7 @@ mod test {
 
     #[test]
     fn dice_works() {
-        #[rustfmt::skip]
-            let cases = [
-                20,
-                i64::MAX,
-            ];
+        let cases = [20, i64::MAX];
         for value in cases {
             let input = format!("d{}", value);
             assert_eq!(dice(&input), Ok(("", Dice::new(value))));
@@ -135,11 +134,7 @@ mod test {
     #[test]
     fn dice_must_be_postive() {
         let as_string = |x: i64| format!("d{}", x);
-        #[rustfmt::skip]
-            let cases = [
-                as_string(-12),
-                as_string(0),
-            ];
+        let cases = [as_string(-12), as_string(0)];
         for case in cases {
             assert!(dice(&case).is_err());
         }
@@ -147,15 +142,32 @@ mod test {
 
     #[test]
     fn constant_works() {
-        #[rustfmt::skip]
-            let cases = [
-                -12,
-                20,
-                i64::MAX
-            ];
+        let cases = [-12, 20, i64::MAX];
         for value in cases {
             let input = format!("{}", value);
             assert_eq!(constant(&input), Ok(("", Constant::new(value))));
+        }
+    }
+
+    //#[test]
+    //fn sample() {
+    //    use quickcheck::Arbitrary;
+    //    let mut gen = quickcheck::Gen::new(10);
+    //    for _ in 0..100 {
+    //        let expr = data::Expr::arbitrary(&mut gen);
+    //        println!("{}", pretty::pretty_expr(expr));
+    //    }
+    //    assert!(false);
+    //}
+
+    quickcheck! {
+        fn law_parse_roundtrip(ast0: data::Expr) -> bool {
+            let source = pretty::pretty_expr(ast0.clone());
+            dbg!(&source);
+            match parse_expr(&*source) {
+                Ok(ast1) => ast0 == ast1,
+                Err(_) => false,
+            }
         }
     }
 }


### PR DESCRIPTION
This is more experimental than serious for adding. It is iffy generating
recursive data structures with something like this where we can't
sensibly bound the size of the AST we generate. We could if we had a
means to continually reduce the generators size as we traverse the
stack, or provide an additional context that allows this. Technically
something like an Arbitrary for a BoundedExpr could work, in which the
size is reduce to a particular depth at each recursive function
invocation. Then the base cases are either leaves of the tree or, when
we've hit the maximum depth we're allowed to go, we only veer towards
leave nodes and prevent further recursion.